### PR TITLE
darwin-mods: add lib.mkDefault for opinions

### DIFF
--- a/darwin-modules/default-darwin.nix
+++ b/darwin-modules/default-darwin.nix
@@ -1,4 +1,4 @@
-{ self, pkgs, ... }: {
+{ self, lib, pkgs, ... }: {
   environment.systemPackages = with pkgs; [
     darwin-option
     darwin-rebuild
@@ -8,7 +8,7 @@
 
   nix.optimise.automatic = true;
   nix.settings = {
-    sandbox = true;
+    sandbox = lib.mkDefault true;
     experimental-features = "nix-command flakes";
   };
 

--- a/darwin-modules/fourier-developer.nix
+++ b/darwin-modules/fourier-developer.nix
@@ -1,11 +1,11 @@
-{ pkgs, ... }: {
+{ lib, pkgs, ... }: {
   nix.settings = {
-    keep-going = true;
-    keep-derivations = true;
-    keep-outputs = true;
+    keep-going = lib.mkDefault true;
+    keep-derivations = lib.mkDefault true;
+    keep-outputs = lib.mkDefault true;
   };
 
   environment.systemPackages = with pkgs; [ vim ];
 
-  nix.linux-builder.enable = true;
+  nix.linux-builder.enable = lib.mkDefault true;
 }

--- a/darwin-modules/hardware/m2-macbook-air.nix
+++ b/darwin-modules/hardware/m2-macbook-air.nix
@@ -1,6 +1,6 @@
-{
+{ lib, ... }: {
   nix.settings = {
-    cores = 6;
-    max-jobs = 4;
+    cores = lib.mkDefault 6;
+    max-jobs = lib.mkDefault 4;
   };
 }


### PR DESCRIPTION
Some of Fourier's recommended modules contain options which people may wish to override. Marking them with `lib.mkDefault` means that module consumers won't have to use `lib.mkForce` or `lib.mkOverride`.